### PR TITLE
fixed minor bug in do_cov

### DIFF
--- a/fuzzware_pipeline/__init__.py
+++ b/fuzzware_pipeline/__init__.py
@@ -598,7 +598,7 @@ def do_cov(args, leftover_args):
 
     if user_defined_basic_blocks:
         # User-provided symbols / basic blocks
-        specific_bbs = (bb & ~1 for bb in resolve_all(symbols, user_defined_basic_blocks))
+        specific_bbs = list(bb & ~1 for bb in resolve_all(symbols, user_defined_basic_blocks))
         print("Resolved basic block addresses: {}".format(",".join(map(hex, specific_bbs))))
 
         # User-provided symbols / basic blocks to skip


### PR DESCRIPTION
This pull request fixes a bug in the fuzzware cov utility, which lead to wrong results. The reason for this bug is the misuse of a generator object.  
The generator is accessed twice, first for a print statement and second as the input of a function. Due to the nature of generators the function always received an empty generator as its input, which resulted in wrong outputs.  
This fix casts the generator to a list, before it is accessed.
