### PR TITLE
Allow corpus minimizer failures from AFL++

### DIFF
--- a/fuzzware_pipeline/session.py
+++ b/fuzzware_pipeline/session.py
@@ -230,13 +230,13 @@ class Session:
             run_corpus_minimizer(harness_args, self.temp_minimization_dir, self.base_input_dir, silent=silent, use_aflpp=self.parent.use_aflpp)
             if not os.listdir(self.base_input_dir):
                 self.parent.add_warning_line("Minimization for fuzzing session '{}' had no inputs remaining, copying generic inputs.".format(self.name))
-                shutil.rmtree(self.base_input_dir)
+                shutil.rmtree(self.base_input_dir, True)
                 shutil.copytree(self.parent.generic_inputs_dir, self.base_input_dir)
         except subprocess.CalledProcessError:
             self.parent.add_warning_line("Minimization for fuzzing session '{}' failed, copying full inputs.".format(self.name))
 
             # In case minimization does not work out, copy all inputs
-            shutil.rmtree(self.base_input_dir)
+            shutil.rmtree(self.base_input_dir, True)
             shutil.copytree(self.temp_minimization_dir, self.base_input_dir)
 
     def start_fuzzers(self):


### PR DESCRIPTION
Prevents the pipeline from exiting when AFL++ cmin runs fails. If minimization failed, the output directory would never be created, and thus rmtree wouldn't be able to delete it. The change allows the calls to rmtree to ignore errors, preventing the file not found exceptions that would terminate the pipeline.