### PR TITLE
Handle error for missing fuzzer_stats

### DIFF
--- a/fuzzware_pipeline/util/eval_utils.py
+++ b/fuzzware_pipeline/util/eval_utils.py
@@ -239,7 +239,11 @@ def derive_input_file_times_from_afl_plot_data(project_base_dir, crashes=False):
             prev_stat_seconds, prev_num_input_files = None, 0
             seconds_and_file_path_counts = parse_afl_plot_data(fuzzer_dir.joinpath("plot_data"), crashes=crashes)
             input_paths = input_paths_for_fuzzer_dir(fuzzer_dir, crashes=crashes)
-            fuzzer_start_time = int(parse_afl_fuzzer_stats(fuzzer_dir.joinpath("fuzzer_stats"))["start_time"])
+            fuzzer_start_time = 0
+            try:
+                fuzzer_start_time = int(parse_afl_fuzzer_stats(fuzzer_dir.joinpath("fuzzer_stats"))["start_time"])
+            except Exception:
+                pass
             for stat_seconds, stat_num_input_files in seconds_and_file_path_counts:
                 if stat_seconds < project_start_seconds:
                     # Assume if we've gone back in time that we're using relative time logs (Like AFL++)


### PR DESCRIPTION
After #5, in cases where the fuzzer encounters an error (And pipeline prints a warning for "Fuzzer instances in session died"), coverage could not be determined, as the fuzzer_stats file is missing. In the cases where this happens, the plot_data is empty anyway, so having fuzzer_start_time set to 0 should be fine, as no data will actually be loaded.

I'm not sure what exactly causes the fuzzer instances to die in the first place, but I think I've seen this in both AFL and AFL++ mode. It generally seems pretty rare though.