### PR TITLE
Prevent file creation race condition

### DIFF
--- a/fuzzware_pipeline/session.py
+++ b/fuzzware_pipeline/session.py
@@ -246,6 +246,7 @@ class Session:
         """
 
         queue_paths = []
+        stats_paths = []
         for i in range(1, self.num_fuzzer_procs + 1):
             logger.info("Starting fuzzer number {}".format(i))
             fuzzer_dir = self.fuzzer_instance_dir(i)
@@ -255,13 +256,14 @@ class Session:
             if not self.start_fuzzer(i):
                 logger.error("Error while starting fuzzer numer: {:d}".format(i))
             queue_paths.append(join(fuzzer_dir, "queue"))
+            stats_paths.append(join(fuzzer_dir, "fuzzer_stats"))
 
             # Wait a bit for fuzzer to choose its CPU affinity to avoid races
             time.sleep(0.05)
 
         # Now wait for all the fuzzer instances to have come up
         num_tries = 0
-        while any([not os.path.exists(path) for path in queue_paths]):
+        while any([not os.path.exists(path) for path in stats_paths]):
             num_tries += 1
             if num_tries >= 10:
                 break


### PR DESCRIPTION
In start_fuzzers, the current code waits for the queue folder to be created, then waits one second before determining if the fuzzer encountered an error.

In my observations, the queue folder is created early in the AFL++ initialisation stage, and its creation does not indicate that the fuzzer has checked for all possible errors. The one second delay does not provide enough time to start the forkserver and test the seed inputs.

In some cases where all of the provided seeds cause a crash, the fuzzer will have no initial seeds to run with and will exit with an error. However, the code that checks the error code would've already executed, finding None as the current exit status.
https://github.com/fuzzware-fuzzer/fuzzware-pipeline/blob/452932acbc9ad481c3ba8fbaf8e4d54b727ceb55/fuzzware_pipeline/session.py#L273-L274

As a result, the start_fuzzers function will return true even if the fuzzer fails. This prevents the pipeline from attempting a wider set of seed inputs.

https://github.com/fuzzware-fuzzer/fuzzware-pipeline/blob/452932acbc9ad481c3ba8fbaf8e4d54b727ceb55/fuzzware_pipeline/pipeline.py#L542-L545

The committed changes wait for the `fuzzer_stats` file to be created, which occurs after initial seeds are run through the forkserver. If an error occurs and this file is not created, the 10 second timeout will trigger, and the pipeline will move onto the next set of input seeds.

Thanks,
CounterCycle