### PR TITLE
crashcontexts: print input paths relative to parent of project dir

### DIFF
--- a/fuzzware_pipeline/__init__.py
+++ b/fuzzware_pipeline/__init__.py
@@ -900,14 +900,15 @@ def do_genstats(args, leftover_args):
                         extra_args += ["-v"]
                 emu_output = str(run_target(config_path, crashing_input, extra_args, get_output=True, silent=True))
                 pc, lr = pc_lr_from_emu_output(emu_output)
-                crashing_input = str(Path(crashing_input).relative_to(projdir))
+                # path to input relative to parent of project dir
+                rel_crashing_input = str(Path(crashing_input).relative_to(os.path.dirname(projdir)))
 
                 if pc is None:
-                    logger.warning(f"An input does not reproduce a crash: {crashing_input}")
+                    logger.warning(f"An input does not reproduce a crash: {rel_crashing_input}")
                     continue
 
-                crash_contexts.setdefault((pc, lr), []).append(crashing_input)
-                logger.info(f"Got (pc, lr) = ({pc:#010x}, {lr:#010x}) for the following input path: {crashing_input}")
+                crash_contexts.setdefault((pc, lr), []).append(rel_crashing_input)
+                logger.info(f"Got (pc, lr) = ({pc:#010x}, {lr:#010x}) for the following input path: {rel_crashing_input}")
 
         crash_context_out_path = os.path.join(projdir, nc.PIPELINE_DIRNAME_STATS, nc.STATS_FILENAME_CRASH_CONTEXTS)
         dump_crash_contexts(crash_context_out_path, crash_contexts)

--- a/fuzzware_pipeline/__init__.py
+++ b/fuzzware_pipeline/__init__.py
@@ -901,7 +901,7 @@ def do_genstats(args, leftover_args):
                         extra_args += ["-v"]
                 emu_output = str(run_target(config_path, crashing_input, extra_args, get_output=True, silent=True))
                 pc, lr = pc_lr_from_emu_output(emu_output)
-                # path to input relative to parent of project dir
+                # path to input relative to current working directory
                 rel_crashing_input = str(Path(crashing_input).relative_to(os.path.dirname(working_directory)))
 
                 if pc is None:

--- a/fuzzware_pipeline/__init__.py
+++ b/fuzzware_pipeline/__init__.py
@@ -887,6 +887,7 @@ def do_genstats(args, leftover_args):
         from .run_target import run_target
         from .util.eval_utils import dump_crash_contexts
         crash_contexts = {}
+        working_directory = os.getcwd()
         for main_dir in main_dirs_for_proj(projdir):
             logger.info(f"Crash contexts from main dir: {main_dir}")
             config_path = None
@@ -901,7 +902,7 @@ def do_genstats(args, leftover_args):
                 emu_output = str(run_target(config_path, crashing_input, extra_args, get_output=True, silent=True))
                 pc, lr = pc_lr_from_emu_output(emu_output)
                 # path to input relative to parent of project dir
-                rel_crashing_input = str(Path(crashing_input).relative_to(os.path.dirname(projdir)))
+                rel_crashing_input = str(Path(crashing_input).relative_to(os.path.dirname(working_directory)))
 
                 if pc is None:
                     logger.warning(f"An input does not reproduce a crash: {rel_crashing_input}")


### PR DESCRIPTION
When generating crash contexts, you may want to quickly test out an input with the emu subcommand, but the printed paths are all relative to the project dir, therefore one always has to prepend `fuzzware-project` to the copied path. Note that this is no problem with the replay subcommand.

This pr changes the behavior so that paths are always printed relative to the parent of the project dir, which should in most cases be the working directory of the callee. I'm still not sure what should be printed there. Maybe stdout should contain paths relative to CWD so that an user can quickly throw them into fuzzware emu? And the crash context file should then contain paths relative to the project dir?